### PR TITLE
DELETE endpoint caption fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ It comes with interactive user interfaces (desktop, web-based) that give you gre
     **method:** `GET` 
     **url:** `localhost:8081/syllabus/edit/{syllabusName}/add/year` 
 >- Delete a year from syllabus by yearId  
-    **method:** `DELTE` 
+    **method:** `DELETE` 
     **url:** `localhost:8081/syllabus/edit/{syllabusName}/delete/year/{yearId}`
 >- Add semester in year  
     **method:** `GET`   
     **url:** `localhost:8081/syllabus/edit/{syllabusName}/{yearId}/add/semester` 
 >- Delete semester from a year  
-    **method:** `DELTE`   
+    **method:** `DELETE`   
     **url:** `localhost:8081/syllabus/edit/{syllabusName}/{yearId}/delete/semester/{semesterId}`   
 >- Add course(course code) in a semester  
-**method:** `POST`   
-**url:** `localhost:8081/api/syllabus/edit/{syllabusName}/{yearId}/{semesterId}/add/course`  
- **data:** `{"courseCode": "CSE 101"}`
->- Get a syllabus by syllabus name(as XML)  
-    **method:** `DELETE` 
+    **method:** `POST`   
+    **url:** `localhost:8081/api/syllabus/edit/{syllabusName}/{yearId}/{semesterId}/add/course`  
+    **data:** `{"courseCode": "CSE 101"}`
+>- Delete a course from a semester by courseCode    
+    **method:** `DELETE`    
     **url:** `localhost:8081/syllabus/edit/{syllabusName}/{yearId}/{semesterId}/delete/course/{courseCode}` 
 
     


### PR DESCRIPTION
## Description

Under the **Syllabus Creator API** section, the final **DELETE** endpoint title is showing `Get a syllabus by syllabus name(as XML)`, which is supposed to be `Delete a course from a semester by courseCode`.

In addition, there are some typo in **DELETE** methods, which have been corrected.

## Type of change

- [X] Readme update
- [X] Typo fix


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My changes generate no new warnings